### PR TITLE
Generate search parameters from base resources 

### DIFF
--- a/implementations/go/base/static/search/mongo_search.go
+++ b/implementations/go/base/static/search/mongo_search.go
@@ -396,7 +396,7 @@ func (m *MongoSearcher) createTokenQueryObject(t *TokenParam) bson.M {
 			if !t.AnySystem {
 				criteria["use"] = ci(t.System)
 			}
-		case "code", "boolean", "string":
+		case "code", "boolean", "string", "id":
 			// criteria isn't a bson, so just return the right answer
 			return buildBSON(p.Path, ci(t.Code))
 		}


### PR DESCRIPTION
For each resource, check its base resources and add their search parameters.  Currently, this means adding search parameters for `_id`, `_lastUpdated`, `_profile`, `_security`, and `_tag` to most resources.  _NOTE: This also removes the need to manually add the `_id` search parameter._
