### PR TITLE
Search include

### DIFF
--- a/implementations/go/base/templates/resource_helpers.go.st
+++ b/implementations/go/base/templates/resource_helpers.go.st
@@ -33,6 +33,28 @@ func StructForResourceName(name string) interface{} {
 	}
 }
 
+func SlicePlusForResourceName(name string, len int, cap int) interface{} {
+	rType := reflect.TypeOf(StructPlusForResourceName(name))
+	return reflect.MakeSlice(reflect.SliceOf(rType), len, cap).Interface()
+}
+
+func NewSlicePlusForResourceName(name string, len int, cap int) interface{} {
+	rSlice := SlicePlusForResourceName(name, len, cap)
+	rSlicePtr := reflect.New(reflect.TypeOf(rSlice))
+	rSlicePtr.Elem().Set(reflect.ValueOf(rSlice))
+	return rSlicePtr.Interface()
+}
+
+func StructPlusForResourceName(name string) interface{} {
+	switch name {
+	<Resources:{r |	case "<r>":
+	return <r>Plus<\u007B><\u007D>
+	}>
+	default:
+		return nil
+	}
+}
+
 func PluralizeLowerResourceName(name string) string {
 	switch name {
 	<Resources:{r |	case "<r>":

--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/GoGenerator.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/GoGenerator.java
@@ -164,11 +164,7 @@ public class GoGenerator extends BaseGenerator implements PlatformGenerator {
         serverWriter.write("package server");
         serverWriter.newLine();
         serverWriter.newLine();
-        serverWriter.write("import (");
-        serverWriter.newLine();
-        serverWriter.write("\t\"github.com/labstack/echo\"");
-        serverWriter.newLine();
-        serverWriter.write(")");
+        serverWriter.write("import \"github.com/labstack/echo\"");
         serverWriter.newLine();
         serverWriter.newLine();
         serverWriter.write("func RegisterController(name string, e *echo.Echo, m []echo.Middleware) {");


### PR DESCRIPTION
Adds support for using the _include search parameter.  Doesn't support recursive includes or includes of references that are _Any_.

Aside from the static go files, the new _generated_ code is the "Plus" versions of each resource, which includes a container for holding the included data.  The general design of that container is largely influenced by the way Mongo requires you to do joins in the pipeline (joined data is represented as new array fields in the object).  In addition to generating the new "Plus" structs, there are also new helper methods for creating new instances and slices of these structs.
