### PR TITLE
Better support for resourceType property in JSON

### DIFF
--- a/implementations/go/base/static/models/constructors.go
+++ b/implementations/go/base/static/models/constructors.go
@@ -1,0 +1,18 @@
+package models
+
+// This file contains manually generated convenience constructors for our
+// models.
+
+// NewOperationOutcome creates a pointer to an OperationOutcome and sets the
+// severity, code and diagnostics for the first issue.
+func NewOperationOutcome(severity, code, diagnostics string) *OperationOutcome {
+	return &OperationOutcome{
+		Issue: []OperationOutcomeIssueComponent{
+			OperationOutcomeIssueComponent{
+				Severity:    severity,
+				Code:        code,
+				Diagnostics: diagnostics,
+			},
+		},
+	}
+}

--- a/implementations/go/base/static/server/resource_controller.go
+++ b/implementations/go/base/static/server/resource_controller.go
@@ -33,14 +33,7 @@ func (rc *ResourceController) IndexHandler(c *echo.Context) error {
 			case search.Error:
 				return c.JSON(x.HTTPStatus, x.OperationOutcome)
 			default:
-				outcome := &models.OperationOutcome{
-					Issue: []models.OperationOutcomeIssueComponent{
-						models.OperationOutcomeIssueComponent{
-							Severity: "fatal",
-							Code:     "exception",
-						},
-					},
-				}
+				outcome := models.NewOperationOutcome("fatal", "exception", "")
 				return c.JSON(http.StatusInternalServerError, outcome)
 			}
 		}
@@ -220,7 +213,8 @@ func (rc *ResourceController) CreateHandler(c *echo.Context) error {
 	resource := models.NewStructForResourceName(rc.Name)
 	err := c.Bind(resource)
 	if err != nil {
-		return err
+		oo := models.NewOperationOutcome("fatal", "exception", err.Error())
+		return c.JSON(http.StatusBadRequest, oo)
 	}
 
 	collection := Database.C(models.PluralizeLowerResourceName(rc.Name))
@@ -256,7 +250,8 @@ func (rc *ResourceController) UpdateHandler(c *echo.Context) error {
 	resource := models.NewStructForResourceName(rc.Name)
 	err := c.Bind(resource)
 	if err != nil {
-		return err
+		oo := models.NewOperationOutcome("fatal", "exception", err.Error())
+		return c.JSON(http.StatusBadRequest, oo)
 	}
 
 	collection := Database.C(models.PluralizeLowerResourceName(rc.Name))

--- a/implementations/go/base/templates/generic_resource_marshaller.go.st
+++ b/implementations/go/base/templates/generic_resource_marshaller.go.st
@@ -2,12 +2,15 @@
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *<Name>) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		<Name>
-	}{
-		ResourceType: "<Name>",
-		<Name>:  *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "<Name>"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to <Name>), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *<Name>) GetBSON() (interface{}, error) {
+	x.ResourceType = "<Name>"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }

--- a/implementations/go/base/templates/generic_resource_unmarshaller.go.st
+++ b/implementations/go/base/templates/generic_resource_unmarshaller.go.st
@@ -17,6 +17,30 @@ func (x *<Name>) UnmarshalJSON(data []byte) (err error) {
 <endif>
 		<\u007D>}>
 		*x = <Name>(x2)
+		<if(IsResource)>
+		return x.checkResourceType()
+		<endif>
 	}
 	return
 }
+
+<if(IsResource)>
+func (x *<Name>) SetBSON(raw bson.Raw) error {
+	x2 := <LowerName>{}
+	err := raw.Unmarshal(&x2)
+	if err != nil {
+		return err
+	}
+	*x = <Name>(x2)
+	return x.checkResourceType()
+}
+
+func (x *<Name>) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "<Name>"
+	} else if x.ResourceType != "<Name>" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be <Name>, instead received %s", x.ResourceType))
+	}
+	return nil
+}
+<endif>

--- a/implementations/go/base/templates/generic_resource_unmarshaller.go.st
+++ b/implementations/go/base/templates/generic_resource_unmarshaller.go.st
@@ -25,16 +25,6 @@ func (x *<Name>) UnmarshalJSON(data []byte) (err error) {
 }
 
 <if(IsResource)>
-func (x *<Name>) SetBSON(raw bson.Raw) error {
-	x2 := <LowerName>{}
-	err := raw.Unmarshal(&x2)
-	if err != nil {
-		return err
-	}
-	*x = <Name>(x2)
-	return x.checkResourceType()
-}
-
 func (x *<Name>) checkResourceType() error {
 	if x.ResourceType == "" {
 		x.ResourceType = "<Name>"

--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/GoGenerator.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/GoGenerator.java
@@ -130,6 +130,7 @@ public class GoGenerator extends BaseGenerator implements PlatformGenerator {
         Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "models", "reference_ext.go")), new File(dirs.get("modelDir")));
         Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "models", "reference.go")), new File(dirs.get("modelDir")));
         Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "models", "fhirdatetime.go")), new File(dirs.get("modelDir")));
+        Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "models", "constructors.go")), new File(dirs.get("modelDir")));
         Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "search", "mongo_search.go")), new File(dirs.get("searchDir")));
         Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "search", "search_param_types.go")), new File(dirs.get("searchDir")));
         Utilities.copyFileToDirectory(new File(Utilities.path(basedDir, "static", "server", "batch_controller.go")), new File(dirs.get("serverDir")));

--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/MgoModel.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/MgoModel.java
@@ -475,7 +475,6 @@ public class MgoModel {
         }
         
         if (isResource(name)) {
-          imports.add("gopkg.in/mgo.v2/bson");
           imports.add("errors");
           imports.add("fmt");
         }


### PR DESCRIPTION
This change ensures that all resources have a resourceType. When going from JSON
into a go struct, the following will now happen:
- If a resourceType is provided and is correct, nothing will happen
- If it is not provided, it will be set in the struct
- If it is provided and wrong, an error will be returned

The same behavior is trur when going from a go struct into MongoDB

Also, the server will now return a 400 and OperationOutcome describing what went
wrong if a resource is PUT/POSTed with the wrong resourceType.
