### PR TITLE
Search revinclude

### DIFF
--- a/implementations/go/base/templates/search_parameter_dictionary.go.st
+++ b/implementations/go/base/templates/search_parameter_dictionary.go.st
@@ -10,6 +10,7 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	"<r.name>": map[string]SearchParamInfo<\u007B>
 <r.searchParams: {s |
 		"<s.name>": SearchParamInfo<\u007B>
+			Resource: "<r.name>",
 			Name: "<s.name>",
 			Type: "<s.type>",
 <if(s.paths)>


### PR DESCRIPTION
Added support for _revinclude searches and added support for third part of include parameters (now you can state the target type of the include when there is more than one possibility; eg. _/Condition?_include=Condition:asserter:Practitioner_).

Also renamed include-related structs and function names to make more sense for _include and _revinclude, as well as to be more descriptive.
