### PR TITLE
Fix bug in resource helper methods

### DIFF
--- a/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/MgoModel.java
+++ b/tools/java/org.hl7.fhir.tools.core/src/org/hl7/fhir/tools/implementations/go/MgoModel.java
@@ -410,8 +410,10 @@ public class MgoModel {
         fileBlock.ln("resourceMap := make(map[string]interface{})");
         for (ResourcePlusIncludeInfo info : includeInfos) {
             fileBlock.bs(String.format("if %s.%s != nil {", alias, info.getField()));
-            fileBlock.bs(String.format("for _, r := range *%s.%s {", alias, info.getField()));
-            fileBlock.ln("resourceMap[r.Id] = &r");
+            // Normally I'd use 'i' as the index, but 'i' is already defined as the alias for resources whose name starts with with 'I'
+            fileBlock.bs(String.format("for idx := range *%s.%s {", alias, info.getField()));
+            fileBlock.ln(String.format("rsc := (*%s.%s)[idx]", alias, info.getField()));
+            fileBlock.ln("resourceMap[rsc.Id] = &rsc");
             fileBlock.es("}");
             fileBlock.es("}");
         }
@@ -423,8 +425,9 @@ public class MgoModel {
         fileBlock.ln("resourceMap := make(map[string]interface{})");
         for (ResourcePlusRevIncludeInfo info : revIncludeInfos) {
             fileBlock.bs(String.format("if %s.%s != nil {", alias, info.getField()));
-            fileBlock.bs(String.format("for _, r := range *%s.%s {", alias, info.getField()));
-            fileBlock.ln("resourceMap[r.Id] = &r");
+            fileBlock.bs(String.format("for idx := range *%s.%s {", alias, info.getField()));
+            fileBlock.ln(String.format("rsc := (*%s.%s)[idx]", alias, info.getField()));
+            fileBlock.ln("resourceMap[rsc.Id] = &rsc");
             fileBlock.es("}");
             fileBlock.es("}");
         }
@@ -436,15 +439,17 @@ public class MgoModel {
         fileBlock.ln("resourceMap := make(map[string]interface{})");
         for (ResourcePlusIncludeInfo info : includeInfos) {
             fileBlock.bs(String.format("if %s.%s != nil {", alias, info.getField()));
-            fileBlock.bs(String.format("for _, r := range *%s.%s {", alias, info.getField()));
-            fileBlock.ln("resourceMap[r.Id] = &r");
+            fileBlock.bs(String.format("for idx := range *%s.%s {", alias, info.getField()));
+            fileBlock.ln(String.format("rsc := (*%s.%s)[idx]", alias, info.getField()));
+            fileBlock.ln("resourceMap[rsc.Id] = &rsc");
             fileBlock.es("}");
             fileBlock.es("}");
         }
         for (ResourcePlusRevIncludeInfo info : revIncludeInfos) {
             fileBlock.bs(String.format("if %s.%s != nil {", alias, info.getField()));
-            fileBlock.bs(String.format("for _, r := range *%s.%s {", alias, info.getField()));
-            fileBlock.ln("resourceMap[r.Id] = &r");
+            fileBlock.bs(String.format("for idx := range *%s.%s {", alias, info.getField()));
+            fileBlock.ln(String.format("rsc := (*%s.%s)[idx]", alias, info.getField()));
+            fileBlock.ln("resourceMap[rsc.Id] = &rsc");
             fileBlock.es("}");
             fileBlock.es("}");
         }


### PR DESCRIPTION
The old code had things like this:

``` go
for _, r := range *a.IncludedOrganizationResourcesReferencedByOwner {
    resourceMap[r.Id] = &r
}
```

The problem with this is that `r` uses the same memory for every iteration, so `&r` will be the same address on every iteration too.  So the last resource in the iteration is the one that wins (and you get lots of repeats of it).

The new code looks like this:

``` go
for idx := range *a.IncludedOrganizationResourcesReferencedByOwner {
    rsc := (*a.IncludedOrganizationResourcesReferencedByOwner)[idx]
    resourceMap[rsc.Id] = &rsc
}
```

I had to use `idx` instead of `i` because `i` is already defined for resources whose name starts with "I" (it's the alias).  For the same reason, I changed `r` to `rsc` to avoid confusion with resources whose name starts with "R" (and therefore already have a defined `r` in scope).
