### PR TITLE
STU3-style sorts

### DIFF
--- a/implementations/go/base/static/search/search_param_types.go
+++ b/implementations/go/base/static/search/search_param_types.go
@@ -117,11 +117,20 @@ func (q *Query) Options() *QueryOptions {
 				options.Offset = offset
 			}
 		case SortParam:
-			sortParam, ok := SearchParameterDictionary[q.Resource][queryParam.Value]
-			if !ok {
-				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
+			// The following supports both DSTU2-style sorts and STU3-style sorts
+			keys := strings.Split(queryParam.Value, ",")
+			for _, key := range keys {
+				desc := strings.HasPrefix(key, "-") || modifier == "desc"
+				sortParam, ok := SearchParameterDictionary[q.Resource][strings.TrimPrefix(key, "-")]
+				if !ok {
+					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
+				}
+				options.Sort = append(options.Sort, SortOption{Descending: desc, Parameter: sortParam})
 			}
-			options.Sort = append(options.Sort, SortOption{Descending: modifier == "desc", Parameter: sortParam})
+			// If this was an STU3-style sort, remember that so we reconstruct the query URL correctly
+			if len(keys) > 1 || strings.HasPrefix(queryParam.Value, "-") {
+				options.IsSTU3Sort = true
+			}
 		case IncludeParam:
 			incls := strings.Split(queryParam.Value, ":")
 			if len(incls) < 2 || len(incls) > 3 {
@@ -222,6 +231,7 @@ type QueryOptions struct {
 	Sort       []SortOption
 	Include    []IncludeOption
 	RevInclude []RevIncludeOption
+	IsSTU3Sort bool
 }
 
 // NewQueryOptions constructs a new QueryOptions with default values (offset = 0, Count = 100)
@@ -232,12 +242,24 @@ func NewQueryOptions() *QueryOptions {
 // URLQueryParameters returns URLQueryParameters representing the query options.
 func (o *QueryOptions) URLQueryParameters() URLQueryParameters {
 	var queryParams URLQueryParameters
-	for _, sort := range o.Sort {
-		sortParamKey := SortParam
-		if sort.Descending {
-			sortParamKey += ":desc"
+	if o.IsSTU3Sort {
+		keys := make([]string, len(o.Sort))
+		for i := range o.Sort {
+			if o.Sort[i].Descending {
+				keys[i] = fmt.Sprintf("-%s", o.Sort[i].Parameter.Name)
+			} else {
+				keys[i] = o.Sort[i].Parameter.Name
+			}
 		}
-		queryParams.Add(sortParamKey, sort.Parameter.Name)
+		queryParams.Add(SortParam, strings.Join(keys, ","))
+	} else {
+		for _, sort := range o.Sort {
+			sortParamKey := SortParam
+			if sort.Descending {
+				sortParamKey += ":desc"
+			}
+			queryParams.Add(sortParamKey, sort.Parameter.Name)
+		}
 	}
 	queryParams.Set(OffsetParam, strconv.Itoa(o.Offset))
 	queryParams.Set(CountParam, strconv.Itoa(o.Count))


### PR DESCRIPTION
Add support for STU3 style sorts as described in the change request:
http://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=9558

For example: http://example.org/fhir/Patient?_sort=gender,-birthdate,family

Note that DSTU2-style sorts also still work. The DSTU2-style version of above is:
http://example.org/fhir/Patient?_sort=gender&_sort:desc=birthdate&_sort=family
