### PR TITLE
Fix ServerURL in server.DefaultConfig

### DIFF
--- a/implementations/go/base/static/server/config.go
+++ b/implementations/go/base/static/server/config.go
@@ -11,7 +11,7 @@ var Database *mgo.Database
 
 // DefaultConfig is the default server configuration
 var DefaultConfig = Config{
-	ServerURL:       "localhost",
+	ServerURL:       "http://localhost:3001",
 	IndexConfigPath: "config/indexes.conf",
 	DatabaseName:    "fhir",
 	Auth:            auth.None(),


### PR DESCRIPTION
The config's ServerURL is used by auth middleware to indicate redirects.  It must be a full URL -- so the default has been changed from "localhost" to "http://localhost:3001".
