### PR TITLE
Fix chained searches with modifiers

### DIFF
--- a/implementations/go/base/static/search/search_param_types.go
+++ b/implementations/go/base/static/search/search_param_types.go
@@ -30,7 +30,7 @@ const (
 	ContainedParam     = "_contained"
 	ContainedTypeParam = "_containedType"
 	OffsetParam        = "_offset" // Custom param, not in FHIR spec
-	FormatParam		   = "_format"
+	FormatParam        = "_format"
 )
 
 var globalSearchParams = map[string]bool{IDParam: true, LastUpdatedParam: true, TagParam: true,
@@ -191,7 +191,7 @@ func (q *Query) Options() *QueryOptions {
 				// Currently we only support JSON
 				panic(createUnsupportedSearchError("MSG_PARAM_INVALID", "Parameter \"_format\" content is invalid"))
 			}
-			
+
 		default:
 			panic(createUnsupportedSearchError("MSG_PARAM_UNKNOWN", fmt.Sprintf("Parameter \"%s\" not understood", param)))
 		}
@@ -994,8 +994,8 @@ func ParseParamNameModifierAndPostFix(fullParam string) (param string, modifier 
 		param = split[0]
 		postfix = split[1]
 	}
-	if strings.Contains(fullParam, ":") {
-		split := strings.SplitN(fullParam, ":", 2)
+	if strings.Contains(param, ":") {
+		split := strings.SplitN(param, ":", 2)
 		param = split[0]
 		modifier = split[1]
 	}


### PR DESCRIPTION
Chained searches with modifiers (e.g., `foo:Bar.baz`) were not properly parsed and resulted in errors.  Now they are properly parsed (e.g., param is `foo`, modifier is `Bar`, and chained query is `baz`).  Addresses #93.
