### PR TITLE
Controllers Use ServerURL to Generate Response URLs

### DIFF
--- a/implementations/go/base/static/server/config.go
+++ b/implementations/go/base/static/server/config.go
@@ -11,7 +11,7 @@ var Database *mgo.Database
 
 // DefaultConfig is the default server configuration
 var DefaultConfig = Config{
-	ServerURL:       "http://localhost:3001",
+	ServerURL:       "",
 	IndexConfigPath: "config/indexes.conf",
 	DatabaseName:    "fhir",
 	Auth:            auth.None(),

--- a/implementations/go/base/static/server/resource_controller.go
+++ b/implementations/go/base/static/server/resource_controller.go
@@ -13,16 +13,18 @@ import (
 
 // ResourceController provides the necessary CRUD handlers for a given resource.
 type ResourceController struct {
-	Name string
-	DAL  DataAccessLayer
+	Name   string
+	DAL    DataAccessLayer
+	Config Config
 }
 
 // NewResourceController creates a new resource controller for the passed in resource name and the passed in
 // DataAccessLayer.
-func NewResourceController(name string, dal DataAccessLayer) *ResourceController {
+func NewResourceController(name string, dal DataAccessLayer, config Config) *ResourceController {
 	return &ResourceController{
-		Name: name,
-		DAL:  dal,
+		Name:   name,
+		DAL:    dal,
+		Config: config,
 	}
 }
 
@@ -43,7 +45,7 @@ func (rc *ResourceController) IndexHandler(c *gin.Context) {
 	}()
 
 	searchQuery := search.Query{Resource: rc.Name, Query: c.Request.URL.RawQuery}
-	baseURL := responseURL(c.Request, rc.Name)
+	baseURL := responseURL(c.Request, rc.Config, rc.Name)
 	bundle, err := rc.DAL.Search(*baseURL, searchQuery)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -106,7 +108,7 @@ func (rc *ResourceController) EverythingHandler(c *gin.Context) {
 	query := fmt.Sprintf("_id=%s&_include=*&_revinclude=*", c.Param("id"))
 
 	searchQuery := search.Query{Resource: rc.Name, Query: query}
-	baseURL := responseURL(c.Request, rc.Name)
+	baseURL := responseURL(c.Request, rc.Config, rc.Name)
 	bundle, err := rc.DAL.Search(*baseURL, searchQuery)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -140,7 +142,7 @@ func (rc *ResourceController) CreateHandler(c *gin.Context) {
 	c.Set("Resource", rc.Name)
 	c.Set("Action", "create")
 
-	c.Header("Location", responseURL(c.Request, rc.Name, id).String())
+	c.Header("Location", responseURL(c.Request, rc.Config, rc.Name, id).String())
 	c.JSON(http.StatusCreated, resource)
 }
 
@@ -164,7 +166,7 @@ func (rc *ResourceController) UpdateHandler(c *gin.Context) {
 	c.Set(rc.Name, resource)
 	c.Set("Resource", rc.Name)
 
-	c.Header("Location", responseURL(c.Request, rc.Name, c.Param("id")).String())
+	c.Header("Location", responseURL(c.Request, rc.Config, rc.Name, c.Param("id")).String())
 	if createdNew {
 		c.Set("Action", "create")
 		c.JSON(http.StatusCreated, resource)
@@ -199,7 +201,7 @@ func (rc *ResourceController) ConditionalUpdateHandler(c *gin.Context) {
 
 	c.Set("Resource", rc.Name)
 
-	c.Header("Location", responseURL(c.Request, rc.Name, id).String())
+	c.Header("Location", responseURL(c.Request, rc.Config, rc.Name, id).String())
 	if createdNew {
 		c.Set("Action", "create")
 		c.JSON(http.StatusCreated, resource)
@@ -241,12 +243,23 @@ func (rc *ResourceController) ConditionalDeleteHandler(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-func responseURL(r *http.Request, paths ...string) *url.URL {
+func responseURL(r *http.Request, config Config, paths ...string) *url.URL {
+
+	if config.ServerURL != "" {
+		theURL := fmt.Sprintf("%s/%s", strings.TrimSuffix(config.ServerURL, "/"), strings.Join(paths, "/"))
+		responseURL, err := url.Parse(theURL)
+
+		if err == nil {
+			return responseURL
+		}
+	}
+
 	responseURL := url.URL{}
-	if r.TLS == nil {
-		responseURL.Scheme = "http"
-	} else {
+
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		responseURL.Scheme = "https"
+	} else {
+		responseURL.Scheme = "http"
 	}
 	responseURL.Host = r.Host
 	responseURL.Path = fmt.Sprintf("/%s", strings.Join(paths, "/"))

--- a/implementations/go/base/templates/routing.go.st
+++ b/implementations/go/base/templates/routing.go.st
@@ -12,7 +12,7 @@ import (
 
 // RegisterController registers the CRUD routes (and middleware) for a FHIR resource
 func RegisterController(name string, e *gin.Engine, m []gin.HandlerFunc, dal DataAccessLayer, config Config) {
-	rc := NewResourceController(name, dal)
+	rc := NewResourceController(name, dal, config)
 	rcBase := e.Group("/" + name)
 
 	if len(m) > 0 {
@@ -87,7 +87,7 @@ func RegisterRoutes(e *gin.Engine, config map[string][]gin.HandlerFunc, dal Data
 	}
 
 	// Batch Support
-	batch := NewBatchController(dal)
+	batch := NewBatchController(dal, serverConfig)
 	batchHandlers := make([]gin.HandlerFunc, len(config["Batch"]))
 	copy(batchHandlers, config["Batch"])
 	batchHandlers = append(batchHandlers, batch.Post)


### PR DESCRIPTION
The resource and batch controllers are now passed the main server Config object. If a ServerURL is set, the controllers use the ServerURL to build the responseURLs used for pagination.
