### PR TITLE
Fixes confusion with JSON mime type

### DIFF
--- a/implementations/go/base/static/server/bind.go
+++ b/implementations/go/base/static/server/bind.go
@@ -1,24 +1,20 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-)
-
-const (
-	MIMEJSONFHIR = "application/json+fhir"
-	MIMEXMLFHIR  = "application/xml+fhir"
 )
 
 func FHIRBind(c *gin.Context, obj interface{}) error {
 	if c.Request.Method == "GET" {
 		return c.BindWith(obj, binding.Form)
 	}
-	switch c.ContentType() {
-	case MIMEJSONFHIR:
+
+	if strings.Contains(c.ContentType(), "json") {
 		return c.BindJSON(obj)
-	case MIMEXMLFHIR:
-		return c.BindWith(obj, binding.XML)
 	}
+
 	return c.Bind(obj)
 }

--- a/implementations/go/base/static/server/server_setup.go
+++ b/implementations/go/base/static/server/server_setup.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"log"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -36,6 +38,8 @@ func NewServer(databaseHost string) *FHIRServer {
 		ValidateHeaders: false,
 	}))
 
+	server.Engine.Use(AbortNonJSONRequests)
+
 	return server
 }
 
@@ -63,4 +67,13 @@ func (f *FHIRServer) Run(config Config) {
 	}
 
 	f.Engine.Run(":3001")
+}
+
+// AbortNonJSONRequests is middleware that responds to any request that Accepts a format
+// other than JSON with a 406 Not Acceptable status.
+func AbortNonJSONRequests(c *gin.Context) {
+	acceptHeader := c.Request.Header.Get("Accept")
+	if acceptHeader != "" && !strings.Contains(acceptHeader, "json") && !strings.Contains(acceptHeader, "*/*") {
+		c.AbortWithStatus(http.StatusNotAcceptable)
+	}
 }


### PR DESCRIPTION
STU3 changes the mime type for FHIR. The new code simply checks to see if "json"
is contained in the ContentType header.

Provided testing for the AbortNonJSONRequests function
Replaced magic number for the status with the constant from the http package.
