### PR TITLE
Fixes confusion with JSON mime type

### DIFF
--- a/implementations/go/base/static/server/bind.go
+++ b/implementations/go/base/static/server/bind.go
@@ -1,24 +1,20 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-)
-
-const (
-	MIMEJSONFHIR = "application/json+fhir"
-	MIMEXMLFHIR  = "application/xml+fhir"
 )
 
 func FHIRBind(c *gin.Context, obj interface{}) error {
 	if c.Request.Method == "GET" {
 		return c.BindWith(obj, binding.Form)
 	}
-	switch c.ContentType() {
-	case MIMEJSONFHIR:
+
+	if strings.Contains(c.ContentType(), "json") {
 		return c.BindJSON(obj)
-	case MIMEXMLFHIR:
-		return c.BindWith(obj, binding.XML)
 	}
+
 	return c.Bind(obj)
 }

--- a/implementations/go/base/static/server/server_setup.go
+++ b/implementations/go/base/static/server/server_setup.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
@@ -96,9 +97,8 @@ func (f *FHIRServer) Run(config Config) {
 // AbortNonJSONRequests is middleware that responds to any request that Accepts a format
 // other than JSON with a 406 Not Acceptable status.
 func AbortNonJSONRequests(c *gin.Context) {
-
 	acceptHeader := c.Request.Header.Get("Accept")
 	if acceptHeader != "" && !strings.Contains(acceptHeader, "json") && !strings.Contains(acceptHeader, "*/*") {
-		c.AbortWithStatus(406)
+		c.AbortWithStatus(http.StatusNotAcceptable)
 	}
 }


### PR DESCRIPTION
STU3 changes the mime type for FHIR. The new code simply checks to see if "json"
is contained in the ContentType header.

Provided testing for the AbortNonJSONRequests function
Replaced magic number for the status with the constant from the http package.
